### PR TITLE
feat: replace dropdown with input for time estimate and update refinement criteria labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/TASK.yaml
+++ b/.github/ISSUE_TEMPLATE/TASK.yaml
@@ -14,11 +14,12 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: scope
+  - type: input
+    id: time_estimate
     attributes:
-      label: Scope
-      options: [S, M, L]
+      label: Time Estimate
+      description: Rough estimate of how much time this task will take to complete in work days (considering time available).
+      placeholder: "e.g. 0.5 work days, 1 work day, 4 work days"
 
   - type: textarea
     id: acceptance
@@ -30,6 +31,7 @@ body:
         - [ ] When the pipeline runs, the new caching is used and reduces build time.
         - [ ] When the feature flag is enabled, the new UI is visible to all users.
         - [ ] When a user can press the green button without getting an error.
+
   - type: textarea
     id: design
     attributes:
@@ -52,10 +54,11 @@ body:
       label: Refinement Criteria
       description: All criteria must be marked with "✅" before the task is refined sufficiently for development to begin.
       options:
-        - label: "'Purpose' is clear and understood"
-        - label: "'Scope' is estimated"
-        - label: "'Acceptance Criteria' are clearly defined"
-        - label: "'Dependencies' and blocking tasks are identified and linked"
-        - label: "'Design / solution direction' is unambiguous"
-        - label: "'Prerequisites' are identified and clearly defined"
-        - label: "No unknown unknowns, so the task can flow uninterrupted"
+        - label: "1. 'Purpose' is clear and understood"
+        - label: "2. 'Design / solution direction' is unambiguous"
+        - label: "3. 'Acceptance Criteria' are clearly defined"
+        - label: "4. 'Prerequisites' are identified and clearly defined"
+        - label: "5. 'Time Estimate' is provided"
+        - label: "6. No unknown unknowns, so the task can flow uninterrupted"
+        - label: "7. 'Dependencies' parent epics aand blocking tasks are identified and linked"
+        - label: "8. 'Sub-issues' are created to break down the work if needed (can be done after refinement)"


### PR DESCRIPTION
Replace the dropdown for time estimates with an input field and enhance the refinement criteria labels for clarity and structure.