### PR TITLE
added spike to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/SPIKE.yaml
+++ b/.github/ISSUE_TEMPLATE/SPIKE.yaml
@@ -1,35 +1,87 @@
-
 name: "🔍 Spike"
 description: "When we need to investigate something before deciding on a solution."
-title: ""
+title: "[spike]: "
 labels: ["type:spike"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        # Spike Investigation
+        
+        A spike is a time-boxed investigation to reduce uncertainty. Use this template to define what you're exploring, how you'll explore it, and what outcomes you expect.
+
   - type: textarea
     id: question
     attributes:
       label: What are we trying to understand?
-      placeholder: >
-        What is it that we dont know?
+      description: Describe the unknown or uncertainty that needs to be resolved before proceeding with implementation.
+      placeholder: |
+        Examples:
+        - Can we integrate with the external API using OAuth2?
+        - What is the performance impact of approach A vs approach B?
+        - Which database schema design best supports our query patterns?
+    validations:
+      required: true
+
+  - type: input
+    id: timebox
+    attributes:
+      label: Time Box
+      description: Maximum time to spend on this investigation.
+      placeholder: "e.g. 4 hours, 8 hours, 2 days"
     validations:
       required: true
 
   - type: textarea
     id: approach
     attributes:
-      label: What will we investigate?
-      placeholder: >
-        What methods, parts of the code, logs, or systems will we investigate?
+      label: Investigation Approach
+      description: What methods, code, documentation, or systems will you investigate? Be specific about your plan.
+      placeholder: |
+        Examples:
+        - Review authentication flow in external API documentation
+        - Build proof-of-concept with both approaches and benchmark performance
+        - Create test database schema and run sample queries
+        - Interview team members who worked on similar features
     validations:
       required: true
 
   - type: textarea
-    id: done
+    id: deliverable
     attributes:
-      label: When is the spike done?
-      placeholder: >
-        Eksempler:
-        - We understand the root cause
-        - We have 1–2 possible solution directions
-        - We know how to test a solution
+      label: Expected Deliverable
+      description: What tangible output will this spike produce?
+      placeholder: |
+        Examples:
+        - [ ] Decision document comparing options A and B with recommendation
+        - [ ] Proof-of-concept code demonstrating feasibility
+        - [ ] Architecture Decision Record (ADR) documenting the chosen approach
+        - [ ] Summary document with findings and next steps
     validations:
       required: true
+
+  - type: textarea
+    id: success_criteria
+    attributes:
+      label: Success Criteria
+      description: How will we know the spike was successful? What questions must be answered?
+      placeholder: |
+        Examples:
+        - [ ] We understand the root cause of the performance issue
+        - [ ] We have 2–3 evaluated solution directions with pros/cons
+        - [ ] We know how to test and validate the chosen solution
+        - [ ] We can estimate implementation effort with confidence
+        - [ ] Technical risks are identified and documented
+    validations:
+      required: true
+
+  - type: textarea
+    id: follow_up
+    attributes:
+      label: Follow-up Actions
+      description: What happens after the spike is complete? (Optional - can be filled in during or after investigation)
+      placeholder: |
+        Examples:
+        - Create task to implement recommended solution
+        - Schedule meeting to discuss findings with team
+        - Create tasks for identified technical debt or risks

--- a/.github/ISSUE_TEMPLATE/SPIKE.yaml
+++ b/.github/ISSUE_TEMPLATE/SPIKE.yaml
@@ -1,7 +1,7 @@
 name: "🔍 Spike"
 description: "When we need to investigate something before deciding on a solution."
 title: "[spike]: "
-labels: ["type:spike"]
+type: Spike
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/SPIKE.yaml
+++ b/.github/ISSUE_TEMPLATE/SPIKE.yaml
@@ -1,0 +1,35 @@
+
+name: "🔍 Spike"
+description: "When we need to investigate something before deciding on a solution."
+title: ""
+labels: ["type:spike"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: What are we trying to understand?
+      placeholder: >
+        What is it that we dont know?
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: What will we investigate?
+      placeholder: >
+        What methods, parts of the code, logs, or systems will we investigate?
+    validations:
+      required: true
+
+  - type: textarea
+    id: done
+    attributes:
+      label: When is the spike done?
+      placeholder: >
+        Eksempler:
+        - We understand the root cause
+        - We have 1–2 possible solution directions
+        - We know how to test a solution
+    validations:
+      required: true


### PR DESCRIPTION
This pull request introduces a new issue template for "spikes" to help guide investigations before deciding on a solution. The template prompts users to clarify the purpose, approach, and completion criteria for a spike.