### PR TITLE
Added Org wide PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,25 @@
+### Review Expectations
+
+<!-- Check one and briefly explain your choice below. -->
+
+- [ ] 🔍 **Thorough review** — Significant or high-risk changes, please review carefully
+- [ ] ⚡ **Quick read-through** — Minor changes, just a sanity check
+- [ ] 🎯 **Focused review** — Please focus on specific areas (describe below)
+
+<!-- Why did you choose this review type? E.g. "Config-only change, low risk" or "Core logic rewritten, needs careful review." -->
+
+---
+
+### What and Why?
+
+---
+
+### Anything for the reviewer to know?
+<!-- Edge cases, trade-offs, areas that need extra attention, etc. -->
+
+---
+
+### Checklist
+- [ ] Follows team conventions
+- [ ] Tests added/updated (if applicable)
+- [ ] Documentation updated (if applicable)


### PR DESCRIPTION
BEWARE! This template is created to support our kata on PR review process, but is not easily enforced across our own repos (copy paste to each repo), it will be released org wide. All repos with local PR templates will not be affected and will still use the local template. All repos that doesn't have a PR template will be affected by this change. 

It is meant to be generic, but please provide feedback in terms of releasing this to the whole GH org. The message below will also be posted in #developer-experience, when this PR is fully approved: 

Hello everybody :wave-frog:

Vi oplever nogle gange vores PR review stage som en bottleneck i vores daglige opgave flow, og derfor vil vi gerne afprøve et generic pull request template, som kan gøre PR reviews nemmere at gribe an. Vi kommer til at placere det på ORG niveau, hvilket betyder at alle der ikke har defineret et lokalt PR template bliver mødt af det. 

Kom endelig med feedback på det!