### PR TITLE
revert: restore CODEOWNERS catch-all for Development Platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tv2/development-platform


### PR DESCRIPTION
Reverts the merge of `chore/remove-codeowners-catchall` (commit 76521bbc9b85996c4ec05077c73332eef2bf02f1) which removed the `* @tv2/development-platform` CODEOWNERS catch-all. This restores the previous CODEOWNERS state.